### PR TITLE
Add yaml v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,5 @@ NOTE: `.json` examples are formatter using https://jsonformatter.curiousconcept.
 ## v1
 
 * [example graph](v1/examples/create_example.cypher)
-* [example schema](v1/examples/schema_example.json)
+* [example json schema](v1/examples/schema_example.json)
+* [example yaml schema](v1/examples/schema_example.yaml)

--- a/v1/examples/schema_example.yaml
+++ b/v1/examples/schema_example.yaml
@@ -1,3 +1,129 @@
+# LPG YAML Schema Options - examples
+
+# Version 1 - simple
 ---
-# TODO: Add the v1 of YAML schema example.
+Nodes:
+    Person:
+        - id: STRING
+        - first_name: STRING
+        - last_name: STRING
+        - years_of_age: INT
+        - date_of_birth: DATETIME
+    Address:
+        - id: STRING
+        - address_line_1: STRING
+        - address_line_2: STRING
+        - city: STRING
+        - post_code: STRING
+EDGES:
+    LIVES_AT:
+        - directed: BOOLEAN
+        - multiedge: BOOLEAN
+        - from_node_type: Person
+        - to_node_type: Address
+        - start_date: DATETIME
+        - end_date: DATETIME
+    WORKS_AT:
+        - directed: BOOLEAN
+        - multiedge: BOOLEAN
+        - from_node_type: Person
+        - to_node_type: Address
+        - start_date: DATETIME
+        - end_date: DATETIME
+...
+
+# Version 2 - extensible
+---
+Nodes:
+    Person:
+        attributes:
+            - id:
+                type: STRING
+                mandatory: BOOLEAN
+            - first_name: 
+                type: STRING
+                mandatory: BOOLEAN
+                indexed: BOOLEAN
+                default: STRING
+            - last_name: 
+                type: STRING
+                mandatory: BOOLEAN
+                indexed: BOOLEAN
+                default: STRING
+            - years_of_age: 
+                type: INT
+                mandatory: BOOLEAN
+                indexed: BOOLEAN
+                default: STRING
+            - date_of_birth: 
+                type: DATETIME
+                mandatory: BOOLEAN
+                indexed: BOOLEAN
+                default: STRING
+        extension:
+            - count: INT
+            - filling_factor: FLOAT
+    Address:
+        attributes:
+            - id:
+                type: STRING
+                mandatory: BOOLEAN
+                indexed: BOOLEAN
+                default: STRING
+            - address_line_1:
+                type: STRING
+                mandatory: BOOLEAN
+                indexed: BOOLEAN
+                default: STRING
+            - address_line_2:
+                type: STRING
+                mandatory: BOOLEAN
+                indexed: BOOLEAN
+                default: STRING
+            - city:
+                type: STRING
+                mandatory: BOOLEAN
+                indexed: BOOLEAN
+                default: STRING
+            - post_code:
+                type: STRING
+                mandatory: BOOLEAN
+                indexed: BOOLEAN
+                default: STRING
+        extension:
+            - count: INT
+            - filling_factor: FLOAT
+EDGES:
+    LIVES_AT:
+        properties:                
+            - directed: BOOLEAN    
+            - multiedge: BOOLEAN   
+            - from_node_type: Person
+            - to_node_type: Address
+        attributes:                
+            - start_date:
+                type: DATETIME     
+                mandatory: BOOLEAN
+            - end_date:
+                type: DATETIME     
+                mandatory: BOOLEAN
+        extension:
+            - count: INT
+            - filling_factor: FLOAT
+    WORKS_AT:
+        properties:                
+            - directed: BOOLEAN    
+            - multiedge: BOOLEAN   
+            - from_node_type: Person
+            - to_node_type: Address 
+        attributes:                
+            - start_date:
+                type: DATETIME     
+                mandatory: BOOLEAN
+            - end_date:
+                type: DATETIME     
+                mandatory: BOOLEAN
+        extension:
+            - count: INT
+            - filling_factor: FLOAT
 ...

--- a/v1/examples/schema_example.yaml
+++ b/v1/examples/schema_example.yaml
@@ -1,0 +1,3 @@
+---
+# TODO: Add the v1 of YAML schema example.
+...

--- a/v1/spec.yaml
+++ b/v1/spec.yaml
@@ -1,4 +1,127 @@
+# LPG YAML Schema Options
+
+# See "examples" folder for examples of the simple and extensible versions
+
+# Version 1 - simple
+# PROS:
+# - Simple
+# - Very human readable
+# CONS:
+# - Not extensible
+
 ---
-# TODO: Add proposal of the v1 spec.
-# NOTE: The format has to support both schema definition and schema retrieval.
+Nodes:                                   # Reserved
+    LabelOne:
+        - id: STRING                     # Reserved
+        - attribute_1: <TYPE>
+        - attribute_2: <TYPE>
+        - attribute_3: <TYPE>
+    LabelTwo:
+        - id: STRING                     # Reserved
+        - attribute_1: <TYPE>
+        - attribute_2: <TYPE>
+        - attribute_3: <TYPE>
+EDGES:                                   # Reserved
+    LABEL_THREE:
+        - directed: BOOLEAN              # Reserved
+        - multiedge: BOOLEAN             # Reserved
+        - from_node_type: <NODE>         # Reserved
+        - to_node_type: <NODE>           # Reserved
+        - attribute_1: <TYPE>
+        - attribute_2: <TYPE>
+    LABEL_FOUR:
+        - directed: BOOLEAN              # Reserved
+        - multiedge: BOOLEAN             # Reserved
+        - from_node_type: <NODE>         # Reserved
+        - to_node_type: <NODE>           # Reserved
+        - attribute_1: <TYPE>
+        - attribute_2: <TYPE>
 ...
+
+# Version 2 - extensible
+# PROS:
+# - Edge-type properties distinct from attributes
+# - Extensible
+# CONS:
+# - Extra levels of indenting / complexity
+# - Less human readable
+
+---
+Nodes:                                  # Reserved
+    LabelOne:
+        attributes:
+            - id:                       # Reserved
+                type: <TYPE>            # Reserved
+                extension_1: <TYPE>
+                extension_2: <TYPE>
+            - attribute_1: 
+                type: STRING            # Reserved
+                extension_1: <TYPE>
+                extension_2: <TYPE>
+            - attribute_2: 
+                type: STRING            # Reserved
+                extension_1: <TYPE>
+                extension_2: <TYPE>
+        extension:
+            - extension_1: <TYPE>
+            - extension_2: <TYPE>
+    LabelTwo:
+        attributes:
+            - id:                       # Reserved
+                type: <TYPE>            # Reserved
+                extension_1: <TYPE>
+                extension_2: <TYPE>
+            - attribute_1: 
+                type: STRING            # Reserved
+                extension_1: <TYPE>
+                extension_2: <TYPE>
+            - attribute_2: 
+                type: STRING            # Reserved
+                extension_1: <TYPE>
+                extension_2: <TYPE>
+        extension:
+            - extension_1: <TYPE>
+            - extension_2: <TYPE>
+EDGES:                                  # Reserved
+    LABEL_THREE:
+        properties:                     # Reserved
+            - directed: <TYPE>          # Reserved
+            - multiedge: <TYPE>         # Reserved
+            - from_node_type: <NODE>    # Reserved
+            - to_node_type: <NODE>      # Reserved
+        attributes:                     # Reserved
+            - attribute_1:
+                type: <TYPE>            # Reserved
+                extension_1: <TYPE>
+                extension_2: <TYPE>
+            - attribute_2:
+                type: <TYPE>            # Reserved
+                extension_1: <TYPE>
+                extension_2: <TYPE>
+        extension:
+            - extension_1: <TYPE>
+            - extension_2: <TYPE>
+    LABEL_FOUR:
+        properties:                     # Reserved
+            - directed: <TYPE>          # Reserved
+            - multiedge: <TYPE>         # Reserved
+            - from_node_type: <NODE>    # Reserved
+            - to_node_type: <NODE>      # Reserved
+        attributes:                     # Reserved
+            - attribute_1:
+                type: <TYPE>            # Reserved
+                extension_1: <TYPE>
+                extension_2: <TYPE>
+            - attribute_2:
+                type: <TYPE>            # Reserved
+                extension_1: <TYPE>
+                extension_2: <TYPE>
+        extension:
+            - extension_1: <TYPE>
+            - extension_2: <TYPE>
+...
+
+# Open question(s)
+# 1. How best to represent single edge types that go between multiple node types?
+#    e.g. Person KNOWS Person AND Person KNOWS Pet
+#    i.e. KNOWS is the same edge type whether it's Person self-edge or Person to Pet

--- a/v1/spec.yaml
+++ b/v1/spec.yaml
@@ -1,0 +1,4 @@
+---
+# TODO: Add proposal of the v1 spec.
+# NOTE: The format has to support both schema definition and schema retrieval.
+...


### PR DESCRIPTION
Initial proposal for YAML LPG schema including both simple and extensible serialisations.

### TODOs

- [ ] @gitbuda Take the ideas from the "hybrid schema" spec because it's aligned with the "unique-label" schema spec (exactly one label per node type)
- [ ] How to represent edges that go between multiple pairs of node types (in both versions) it's how to make the syntax nicer?